### PR TITLE
Fix keys to access deezer data dict

### DIFF
--- a/pydeezer/cli.py
+++ b/pydeezer/cli.py
@@ -63,19 +63,19 @@ def download(arl, media_type, download_dir, quality):
                 "name": album["title"] + " - " + album["artist"]["name"],
                 "value": album["id"],
                 "short": album["title"]
-            } for album in deezer.search_albums(query)]
+            } for album in deezer.search_albums(query)['data']]
         elif _media_type == "PLAYLIST":
             return [{
                 "name": playlist["title"] + " - " + playlist["user"]["name"],
                 "value": playlist["id"],
                 "short": playlist["title"]
-            } for playlist in deezer.search_playlists(query)]
+            } for playlist in deezer.search_playlists(query)['data']]
         elif _media_type == "ARTIST":
             return [{
                 "name": artist["name"],
                 "value": artist["id"],
                 "short": artist["name"]
-            } for artist in deezer.search_artists(query)]
+            } for artist in deezer.search_artists(query)['data']]
 
     def track_choices(answers):
         if "media_type" in answers:
@@ -185,10 +185,10 @@ def download(arl, media_type, download_dir, quality):
 
     for track in tracks:
         t = deezer.get_track(track)
-        info = t["info"]["DATA"]
+        info = t["info"]
 
-        artist_name = util.clean_filename(info["ART_NAME"])
-        album_name = util.clean_filename(info["ALB_TITLE"])
+        artist_name = util.clean_filename(info["artist"]["name"])
+        album_name = util.clean_filename(info["album"]["title"])
 
         download_path = path.join(download_dir, artist_name, album_name)
         util.create_folders(download_path)


### PR DESCRIPTION
Fix errors when trying to download using the cli.

## Error

```
Traceback (most recent call last):
  File "pydeezer/venv/bin/pydeezer", line 11, in <module>
    load_entry_point('py-deezer', 'console_scripts', 'pydeezer')()
  File "pydeezer/venv/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "pydeezer/venv/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "pydeezer/venv/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "pydeezer/venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "pydeezer/venv/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "pydeezer/pydeezer/cli.py", line 178, in download
    answers = prompt(questions)
  File "pydeezer/venv/lib/python3.9/site-packages/PyInquirer/prompt.py", line 34, in prompt
    question['choices'] = choices(answers)
  File "pydeezer/pydeezer/cli.py", line 74, in search_choices
    return [{
  File "pydeezer/pydeezer/cli.py", line 75, in <listcomp>
    "name": artist["name"],
TypeError: string indices must be integers
```